### PR TITLE
Check if url exists before adding cookies

### DIFF
--- a/src/lib/generateCode/index.js
+++ b/src/lib/generateCode/index.js
@@ -61,7 +61,7 @@ class CodeGenerator {
       }
 
       jar.cookies.forEach(cookie => {
-        if (this.url.includes(cookie.domain) && (cookie.path === '/' || this.url.includes(cookie.path))) {
+        if (this.url && this.url.includes(cookie.domain) && (cookie.path === '/' || this.url.includes(cookie.path))) {
           cookies.push({
             key: cookie.key,
             value: cookie.value


### PR DESCRIPTION
Hello Jozsef,

I had a problem trying to generating documentation from my insomnia files. I'm not really aware of the reasons but it was failing trying to load insomnia.json file which was instead available. 

I was serving it with 'npx serve'.

The code was crashing on the line I edited because the url was null when you check the domain for cookies.

I added an existence check on the url and it started working but I don't know if something can be broken now. Apparentely not.

Thanks for this awesome project