### PR TITLE
fix applyEnv regexp

### DIFF
--- a/src/lib/applyEnv.js
+++ b/src/lib/applyEnv.js
@@ -4,7 +4,7 @@ export default function (value, env) {
   }
 
   Object.keys(env.data).forEach(key => {
-    value = value.replace(new RegExp('{{([\\s' + key + ']+)}}', 'g'), env.data[key]);
+    value = value.replace(new RegExp('{{(\\s*' + key + '\\s*)}}', 'g'), env.data[key]);
   });
 
   return value;


### PR DESCRIPTION
I corrected the applyEnv bug.   String in `[]` will be matched as single characters.