### PR TITLE
#8 Env variable substitution for groups and requests' body and params 

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,11 +1,14 @@
 <script>
   import Sidebar from './components/Sidebar.svelte';
   import Content from './components/Content.svelte';
+  import applyEnvForObject from './lib/applyEnvForObject';
 
   export let config;
 
   let envId = 0;
   $: env = config.environments[envId];
+  $: requests = applyEnvForObject(config.requests, config.environments[envId]);
+  $: groups = applyEnvForObject(config.groups, config.environments[envId]);
 
   const jsonUrl = window.location.origin + window.INSOMNIA_URL;
   const runInInsomniaLink = `https://insomnia.rest/run/?label=${encodeURIComponent(config.workspace.name)}&uri=${encodeURIComponent(jsonUrl)}`;
@@ -51,10 +54,10 @@
 </header>
 
 <section class="wrapper">
-  <Sidebar config={config} visible={menuVisible} />
+  <Sidebar requests={requests} groups={groups} workspace={config.workspace} visible={menuVisible} />
   <Content
-    requests={config.requests}
-    groups={config.groups}
+    requests={requests}
+    groups={groups}
     workspace={config.workspace}
     cookiejars={config.cookiejars}
     {env}

--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -1,12 +1,14 @@
 <script>
   import Group from './groups/Group.svelte';
 
-  export let config;
+  export let requests;
+  export let groups;
+  export let workspace;
   export let visible;
 </script>
 
 <aside class:visible>
-  <Group name={config.workspace.name} children={config.groups} requests={config.requests} root={true} expanded />
+  <Group name={workspace.name} children={groups} requests={requests} root={true} expanded />
 </aside>
 
 <style>

--- a/src/components/content/Request.svelte
+++ b/src/components/content/Request.svelte
@@ -10,7 +10,6 @@
     tables: true
   });
 
-  import applyEnv from '../../lib/applyEnv';
   import generateCode from '../../lib/generateCode';
   import ContentGenerator from '../../lib/content';
 
@@ -25,14 +24,14 @@
   let copyButton;
   let codeElement;
 
-  const content = new ContentGenerator(request);
+  $: content = new ContentGenerator(request);
 
   $: reqData = {
     method: request.method,
-    url: applyEnv(request.url, env),
-    name: applyEnv(request.name, env),
-    description: applyEnv(request.description, env),
-    exampleResponse: applyEnv(request.exampleResponse, env)
+    url: request.url,
+    name: request.name,
+    description: request.description,
+    exampleResponse: request.exampleResponse
   };
 
   $: exampleCode = generateCode(request, reqData.url, language, cookiejars);

--- a/src/components/content/Rows.svelte
+++ b/src/components/content/Rows.svelte
@@ -1,5 +1,4 @@
 <script>
-  import applyEnv from '../../lib/applyEnv';
   import Request from './Request.svelte';
   import Group from './Group.svelte';
 

--- a/src/lib/applyEnvForObject.js
+++ b/src/lib/applyEnvForObject.js
@@ -1,0 +1,28 @@
+import applyEnv from './applyEnv';
+
+export default function applyEnvForObject(object, env) {
+  let obj = object;
+  if (typeof obj === 'object') {
+    obj = JSON.parse(JSON.stringify(object));
+    replaceObjectValues(obj, env);
+  }
+  return obj;
+}
+
+function replaceObjectValues(obj, env) {
+  Object.keys(obj).forEach(key => {
+    if (obj[key] !== null) {
+      switch (typeof obj[key]) {
+        case 'object':
+          replaceObjectValues(obj[key], env);
+          break;
+        case 'string':
+          obj[key] = applyEnv(obj[key], env);
+          break;
+      }
+    }
+  });
+}
+
+
+

--- a/src/lib/applyEnvForObject.test.js
+++ b/src/lib/applyEnvForObject.test.js
@@ -1,0 +1,134 @@
+import applyEnv from './applyEnv';
+import { expect } from 'chai';
+import applyEnvForObject from "./applyEnvForObject";
+
+describe('applyEnvForObject', function () {
+  it('should replace env vars for object and it\'s nested fields', function () {
+    const env = {
+      data: {
+        url: 'http://localhost',
+        method: 'GET',
+        paramOne: 'one',
+        paramTwo: 'two',
+      }
+    };
+
+    const request = {
+      url: "{{url}}",
+      method: "{{method}}",
+      nestedObject: {
+        paramOne: "{{paramOne}}",
+        paramTwo: "{{paramTwo}}",
+        arrayValue: ["{{paramOne}}", "{{paramTwo}}", null],
+        nestedArrayValue: [["{{paramOne}}"], ["{{paramTwo}}"], [null]],
+        nestedArrayObject: [{
+          paramOne: "{{paramOne}}",
+          paramTwo: "{{paramTwo}}"
+        }, {
+          paramOne: "{{paramOne}}",
+          paramTwo: "{{paramTwo}}"
+        }],
+        nullField: null
+      }
+
+    }
+    return expect(applyEnvForObject(request, env)).to.eql(
+        {
+          url: 'http://localhost',
+          method: 'GET',
+          nestedObject: {
+            paramOne: "one",
+            paramTwo: "two",
+            arrayValue: ["one", "two", null],
+            nestedArrayValue: [["one"], ["two"], [null]],
+            nestedArrayObject: [{
+              paramOne: "one",
+              paramTwo: "two"
+            }, {
+              paramOne: "one",
+              paramTwo: "two"
+            }],
+            nullField: null
+          }
+        }
+    )
+  });
+
+  it('should replace env vars for array', function () {
+    const env = {
+      data: {
+        url: 'http://localhost',
+        method: 'GET',
+        paramOne: 'one',
+        paramTwo: 'two',
+      }
+    };
+
+    const request = [{
+      url: "{{url}}",
+      method: "{{method}}",
+      nestedObject: {
+        paramOne: "{{paramOne}}",
+        paramTwo: "{{paramTwo}}",
+        arrayValue: ["{{paramOne}}", "{{paramTwo}}", null],
+        nestedArrayValue: [["{{paramOne}}"], ["{{paramTwo}}"], [null]],
+        nestedArrayObject: [{
+          paramOne: "{{paramOne}}",
+          paramTwo: "{{paramTwo}}"
+        }, {
+          paramOne: "{{paramOne}}",
+          paramTwo: "{{paramTwo}}"
+        }],
+        nullField: null
+      }
+    }]
+
+    return expect(applyEnvForObject(request, env)).to.eql(
+        [{
+          url: 'http://localhost',
+          method: 'GET',
+          nestedObject: {
+            paramOne: "one",
+            paramTwo: "two",
+            arrayValue: ["one", "two", null],
+            nestedArrayValue: [["one"], ["two"], [null]],
+            nestedArrayObject: [{
+              paramOne: "one",
+              paramTwo: "two"
+            }, {
+              paramOne: "one",
+              paramTwo: "two"
+            }],
+            nullField: null
+          }
+        }]
+    )
+  });
+
+  it('should replace env vars for strings', function () {
+    const env = {
+      data: {
+        url: 'http://localhost',
+        method: 'GET',
+        paramOne: 'one',
+        paramTwo: 'two',
+      }
+    };
+    const request = "string"
+    return expect(applyEnvForObject(request, env)).to.eql("string")
+  });
+
+  it('should replace env vars for number', function () {
+    const env = {
+      data: {
+        url: 'http://localhost',
+        method: 'GET',
+        paramOne: 'one',
+        paramTwo: 'two',
+      }
+    };
+    const request = 1
+    return expect(applyEnvForObject(request, env)).to.eql(1)
+  });
+});
+


### PR DESCRIPTION
Replacing the env variables should happen for every value across the
request object. This solves the replace that needs to happen in code
regeration alse