### PR TITLE
Fix basic HTTP authentication header generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Add mandatory `Basic ` prefix to `"Authorization"` header (thanks to @michaelbaudino)
+
 ## 0.3.2 - 2020-01-09
 ### Added
 - Tutorial and demo video in the README

--- a/src/lib/generateCode/auth/basic.js
+++ b/src/lib/generateCode/auth/basic.js
@@ -4,6 +4,6 @@ export function getBasicAuthHeader(username = null, password = null) {
 
   return {
     name: 'Authorization',
-    value: authString
+    value: `Basic ${authString}`
   };
 };

--- a/src/lib/generateCode/auth/basic.test.js
+++ b/src/lib/generateCode/auth/basic.test.js
@@ -9,18 +9,22 @@ describe('Basic authentication', function () {
   describe('#getBasicAuthHeader', function () {
     it('should properly convert username:password string to base64', function () {
       const result = getBasicAuthHeader('joe', 'joe1234');
+      const [method, value] = result.value.split(' ');
       expect(result.name).to.eql('Authorization');
-      return expect(Buffer.from(result.value, 'base64').toString()).to.eql('joe:joe1234');
+      expect(method).to.eql('Basic');
+      return expect(Buffer.from(value, 'base64').toString()).to.eql('joe:joe1234');
     });
 
     it('should not encode username if not provided', function () {
       const result = getBasicAuthHeader(null, 'joe1234');
-      return expect(Buffer.from(result.value, 'base64').toString()).to.eql(':joe1234');
+      const [_method, value] = result.value.split(' ');
+      return expect(Buffer.from(value, 'base64').toString()).to.eql(':joe1234');
     });
 
     it('should not encode password if not provided', function () {
       const result = getBasicAuthHeader('joe');
-      return expect(Buffer.from(result.value, 'base64').toString()).to.eql('joe:');
+      const [_method, value] = result.value.split(' ');
+      return expect(Buffer.from(value, 'base64').toString()).to.eql('joe:');
     });
   });
 });


### PR DESCRIPTION
It was previously missing the "Basic " prefix in the header value, resulting in authentication failed.