### PR TITLE
Add treatment to use directories

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ async function app() {
 
   const url = process.env.NODE_ENV === 'demo'
     ? '/insomnia-documenter/insomnia.json'
-    : `${rootPath}/insomnia.json`;
+    : `${rootPath}${window.location.pathname}insomnia.json`;
 
   window.INSOMNIA_URL = url;
 


### PR DESCRIPTION
GithubPages use directories to publish repositories, same this **https://company.github.io/repository/**.
The build of insomnia-documenter not run in directories, but a simple adjust using pathname solve this problem.