### PR TITLE
Update php.js

### DIFF
--- a/src/lib/generateCode/targets/php.js
+++ b/src/lib/generateCode/targets/php.js
@@ -38,11 +38,11 @@ curl_setopt_array($curl, array(
   }
 
   if (req.authHeader) {
-    headers.push(`${req.authHeader.name}: ${req.authHeader.value}`);
+    headers.push(`'${req.authHeader.name}: ${req.authHeader.value}'`);
   }
 
   if (headers.length) {
-    opts.push(`CURLOPTS_HTTPHEADER => array(
+    opts.push(`CURLOPT_HTTPHEADER => array(
     ${headers.join(',\n    ')}
   )`);
   }


### PR DESCRIPTION
CURLOPTS_HTTPHEADER doesn't exist, instead use CURLOPT_HTTPHEADER.
Headers need to be strings, and there are no single qoutes present in the generated code.