### PR TITLE
feat: create tag favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Like [Postman Documenter](https://www.getpostman.com/api-documentation-generator
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Requirements](#requirements)
 - [Getting Started](#getting-started)
   - [Using `npx`](#using-npx)
   - [By installing the package globally](#by-installing-the-package-globally)
   - [Options](#options)
-  - [Using a GitHub Release](#using-a-github-release)
+  - [Using a GitHub release](#using-a-github-release)
 - [Updating the API](#updating-the-api)
 - [Custom Root Paths](#custom-root-paths)
 - [Running the Page Locally](#running-the-page-locally)
@@ -49,6 +50,7 @@ insomnia-documenter --config /path/to/insomnia/config.json
 Options:
   -c, --config <location>  Location of the exported Insomnia JSON config.
   -l, --logo <location>    Project logo location (48x48px PNG).
+  -f, --favicon <location>    Project favicon location (ICO).
   -o, --output <location>  Where to save the file (defaults to current working directory).
   -h, --help               output usage information
 ```
@@ -61,7 +63,7 @@ Alternatively, you can start using Insomnia Documenter by downloading a release 
 
 Updating the API is super simple! Since Insomnia Documenter is a plug-and-play web app, you can just replace your `insomnia.json` with your new exported JSON file. Just make sure it's called `insomnia.json`.
 
-The same actually applies to the logo as well (`logo.png`).
+The same actually applies to the logo (`logo.png`) e favicon (`favicon.ico`) as well .
 
 ## Custom Root Paths
 

--- a/bin/generate.js
+++ b/bin/generate.js
@@ -9,10 +9,11 @@ const mkdirp = require('mkdirp');
 program
   .option('-c, --config <location>', 'Location of the exported Insomnia JSON config.')
   .option('-l, --logo <location>', 'Project logo location (48x48px PNG).')
+  .option('-f, --favicon <location>', 'Project favicon location (ICO).')
   .option('-o, --output <location>', 'Where to save the file (defaults to current working directory).')
   .parse(process.argv);
 
-const { config, logo, output } = program;
+const { config, logo, favicon, output } = program;
 
 if (!config) {
   console.log('You must provide an exported Insomnia config (Preferences -> Data -> Export Data -> Current Workspace).');
@@ -22,6 +23,7 @@ if (!config) {
 const PACKAGE_DIST_PATH = path.resolve(__dirname, '..', 'public');
 const outputPath = output ? path.join(process.cwd(), output) : process.cwd();
 const logoPath = logo && path.join(process.cwd(), logo);
+const faviconPath = favicon && path.join(process.cwd(), favicon);
 const configPath = path.join(process.cwd(), config);
 
 console.log('Getting files ready...');
@@ -45,6 +47,11 @@ mkdirp(outputPath, err => {
   if (logoPath) {
     console.log('Adding custom logo...');
     fs.copyFileSync(logoPath, path.join(outputPath, 'logo.png'));
+  }
+
+  if (faviconPath) {
+    console.log('Adding custom favicon...');
+    fs.copyFileSync(faviconPath, path.join(outputPath, 'favicon.ico'));
   }
 
   console.log('\n * * * Done! * * *\nYour documentation has been created and it\'s ready to be deployed!');


### PR DESCRIPTION
A need that always arose when using the lib, is that when generating the automated build by the ci/cd script, when I added the parameter for logo (`--logo logo.png`), only the logo was updated, and the favico it was updated to insomnia default, not my custom favicon.

Added this feature to the library, and updated the documentation.

Insert favicon:  
`--favicon favicon.ico`

I hope it can be useful to everyone.